### PR TITLE
Fix various UI and Playback issues on mobile browser

### DIFF
--- a/src/assets/scss/Global/index.scss
+++ b/src/assets/scss/Global/index.scss
@@ -41,7 +41,9 @@ body {
     -webkit-text-size-adjust: 100%;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     height: 100vh;
+    height: 100dvh;
     width: 100vw;
+    width: 100dvw;
     overflow: hidden;
     margin: 0;
     background-color: $body;

--- a/src/components/NowPlaying/Header.vue
+++ b/src/components/NowPlaying/Header.vue
@@ -15,8 +15,8 @@
         <img v-motion-fade class="rounded" :src="paths.images.thumb.large + queue.currenttrack?.image" />
       </RouterLink>
       <NowPlayingInfo @handle-fav="handleFav" />
-      <Progress v-if="isSmallPhone" />
-      <div v-if="isSmallPhone" class="below-progress">
+      <Progress v-if="isLargerMobile || isSmallPhone" />
+      <div v-if="isLargerMobile || isSmallPhone" class="below-progress">
         <div class="time">
           {{ formatSeconds(queue.duration.current) }}
         </div>
@@ -26,7 +26,7 @@
         </div>
       </div>
     </div>
-    <h3 class="nowplaying_title" v-if="queue.next">Up Next</h3>
+    <h3 v-if="queue.next" class="nowplaying_title">Up Next</h3>
     <SongItem
       v-if="queue.next"
       :track="queue.next"
@@ -43,7 +43,7 @@ import { paths } from "@/config";
 import { dropSources, favType } from "@/enums";
 import favoriteHandler from "@/helpers/favoriteHandler";
 import { Routes } from "@/router";
-import { isSmallPhone } from "@/stores/content-width";
+import { isSmallPhone, isLargerMobile } from "@/stores/content-width";
 import useQueueStore from "@/stores/queue";
 import { formatSeconds } from "@/utils";
 

--- a/src/components/nav/ProfileDropdown.vue
+++ b/src/components/nav/ProfileDropdown.vue
@@ -36,7 +36,7 @@ const modal = useModal()
 <style lang="scss">
 .profiledrop {
     position: absolute;
-    z-index: 10;
+    z-index: 9999;
     top: 2.25rem;
     right: 0;
     width: 10rem;

--- a/src/components/shared/DropDown.vue
+++ b/src/components/shared/DropDown.vue
@@ -8,7 +8,7 @@
                 :title="reverse !== 'hide' ? `sort by: ${current.title} ${reverse ? 'Descending' : 'Ascending'}`.toUpperCase() : undefined"
             >
                 <span class="ellip">{{ current.title }}</span>
-                <ArrowSvg :class="{ reverse }" v-if="reverse !== 'hide'" />
+                <ArrowSvg :class="{ reverse }" class="dropdown-arrow" v-if="reverse !== 'hide'" />
             </button>
             <div v-if="showDropDown" ref="dropOptionsRef" class="options rounded no-scroll shadow-lg">
                 <div
@@ -68,6 +68,12 @@ onClickOutside(dropOptionsRef, e => {
 <style lang="scss">
 .smdropdown {
     z-index: 1000;
+
+    .dropdown-arrow {
+        width: 100%;
+        aspect-ratio: 1;
+    }
+
     .selected {
         width: 100%;
         display: grid;

--- a/src/helpers/mediaNotification.ts
+++ b/src/helpers/mediaNotification.ts
@@ -63,5 +63,12 @@ export default () => {
     navigator.mediaSession.setActionHandler("nexttrack", () => {
       queue.playNext();
     });
+    navigator.mediaSession.setActionHandler("seekto", (details) => {
+      if (details.fastSeek||details.seekTime == undefined) {
+        return;
+      }
+
+      queue.seek(details.seekTime);
+    });
   }
 };

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -15,6 +15,76 @@ import updateMediaNotif from '@/helpers/mediaNotification'
 import { crossFade } from '@/utils/audio/crossFade'
 import updatePageTitle from '@/utils/updatePageTitle'
 
+class AudioSource {
+    private sources: HTMLAudioElement[] = []
+    private playingSourceIndex: number = 0
+    private handlers: { [key: string]: (err: Event | string) => void } = {}
+    settings: ReturnType<typeof useSettings> | null = null
+
+    constructor() {
+        this.sources = [new Audio(), new Audio()]
+
+        this.sources.forEach((audio, index) => {
+            audio.style.display = 'none'
+            audio.id = `source-${index}`
+            document.body.appendChild(audio)
+        })
+    }
+
+    get standbySource() {
+        return this.sources[1 - this.playingSourceIndex]
+    }
+    get playingSource() {
+        return this.sources[this.playingSourceIndex]
+    }
+
+    preloadWithUri(uri: string) {
+        const audio = this.standbySource
+        if (!this.settings) return audio
+        audio.src = uri
+        audio.muted = this.settings.mute
+        audio.volume = this.settings.volume
+        audio.load()
+        return audio
+    }
+
+    switchSources() {
+        if (!this.settings) return
+        crossFade({
+            audio: this.playingSource,
+            duration: this.settings.crossfade_duration,
+            start_volume: this.settings.volume,
+            then_destroy: false,
+        })
+
+        this.playingSourceIndex = 1 - this.playingSourceIndex
+    }
+
+    assignSettings(settings: ReturnType<typeof useSettings>) {
+        this.settings = settings
+        this.sources.forEach(audio => {
+            audio.muted = settings.mute
+            audio.volume = settings.volume
+        })
+    }
+
+    assignEventHandlers(onPlaybackError: (err: Event | string) => void) {
+        this.handlers = {
+            onPlaybackError,
+        }
+    }
+
+    pausePlayingSource() {
+        navigator.mediaSession.playbackState = 'paused'
+        this.playingSource.pause()
+    }
+
+    async playPlayingSource(onerror: (err: Event | string) => void = this.handlers.onPlaybackError) {
+        navigator.mediaSession.playbackState = 'playing'
+        return this.playingSource.play().catch(onerror)
+    }
+}
+
 export function getUrl(filepath: string, trackhash: string, use_legacy: boolean) {
     // INFO: Force using legacy streaming endpoint until
     // we change the playback engine to properly support
@@ -27,7 +97,8 @@ export function getUrl(filepath: string, trackhash: string, use_legacy: boolean)
     )}&container=${streaming_container}&quality=${streaming_quality}`
 }
 
-let audio = new Audio()
+const audioSource = new AudioSource()
+let audio = audioSource.playingSource
 const buffering = ref(true)
 const maxSeekPercent = ref(0)
 
@@ -40,6 +111,8 @@ export const usePlayer = defineStore('player', () => {
     const settings = useSettings()
     const tracklist = useTracklist()
 
+    audioSource.assignSettings(settings)
+
     let currentAudioData = {
         filepath: '',
         silence: {
@@ -50,7 +123,7 @@ export const usePlayer = defineStore('player', () => {
 
     let nextAudioData = {
         filepath: '',
-        audio: new Audio(),
+        audio: audioSource.standbySource,
         loaded: false,
         ticking: false,
         silence: {
@@ -70,9 +143,6 @@ export const usePlayer = defineStore('player', () => {
 
     function clearNextAudioData() {
         nextAudioData.filepath = ''
-        nextAudioData.audio.removeEventListener('canplay', () => null)
-        nextAudioData.audio = new Audio()
-
         nextAudioData.loaded = false
         nextAudioData.ticking = false
         nextAudioData.silence = {
@@ -95,19 +165,11 @@ export const usePlayer = defineStore('player', () => {
     }
 
     const audio_onerror = (err: Event | string) => {
-        const { showNotification } = useToast()
-
         if (typeof err != 'string') {
             err.stopImmediatePropagation()
         }
 
-        if (err instanceof DOMException) {
-            queue.playPause()
-
-            return toast.showNotification('Tap anywhere in the page and try again (autoplay blocked))', NotifType.Error)
-        }
-
-        showNotification("Can't load: " + queue.currenttrack.title, NotifType.Error)
+        handlePlayErrors(err)
 
         // if (queue.currentindex !== tracklist.tracklist.length - 1) {
         //     if (!queue.playing) return
@@ -129,13 +191,17 @@ export const usePlayer = defineStore('player', () => {
         // queue.setPlaying(false)
     }
 
-    const handlePlayErrors = (e: Event) => {
+    const handlePlayErrors = (e: Event | string) => {
         if (e instanceof DOMException) {
-            queue.playPause()
+            if(e.name === 'NotAllowedError') {
+                queue.playPause()
+                return toast.showNotification('Tap anywhere in the page and try again (autoplay blocked))', NotifType.Error)
+            }
 
-            return toast.showNotification('Tap anywhere in the page and try again (autoplay blocked))', NotifType.Error)
+            return toast.showNotification('Player Error: ' + e.message, NotifType.Error)
         }
 
+        queue.playNext() // skip unplayable track
         toast.showNotification("Can't load: " + queue.currenttrack.title, NotifType.Error)
     }
 
@@ -167,14 +233,14 @@ export const usePlayer = defineStore('player', () => {
 
     const onAudioCanPlay = () => {
         if (!queue.playing) {
-            audio.pause()
+            audioSource.pausePlayingSource()
             return
         }
         // queue.setDurationFromFile(audio.duration == Infinity ? queue.currenttrack.duration || 0 : audio.duration)
         // console.log(audio.duration == Infinity)
         queue.setDurationFromFile(queue.currenttrack.duration || 0)
 
-        audio.play().catch(handlePlayErrors)
+        audioSource.playPlayingSource(handlePlayErrors)
     }
 
     const onAudioEnded = () => {
@@ -188,7 +254,7 @@ export const usePlayer = defineStore('player', () => {
         if (nextAudioData.loaded === false) {
             console.log('next audio not loaded')
             clearNextAudioData()
-            queue.autoPlayNext()
+            queue.playNext()
         }
     }
 
@@ -256,31 +322,23 @@ export const usePlayer = defineStore('player', () => {
         if (nextAudioData.filepath === queue.next.filepath) return
 
         const uri = getUrl(queue.next.filepath, queue.next.trackhash, settings.use_legacy_streaming_endpoint)
-        nextAudioData.audio = new Audio(uri)
-        nextAudioData.audio.muted = settings.mute
+        nextAudioData.audio = audioSource.preloadWithUri(uri)
         nextAudioData.filepath = queue.next.filepath
         nextAudioData.audio.oncanplay = handleNextAudioCanPlay
-        nextAudioData.audio.load()
     }
 
     function moveLoadedForward() {
         clearEventHandlers(audio)
 
-        const oldAudio = audio
-        queue.setManual(false)
-        crossFade({
-            audio: oldAudio,
-            duration: settings.crossfade_duration,
-            start_volume: settings.volume,
-            then_destroy: true,
-        })
+        audioSource.switchSources()
 
         // INFO: Set stuff
-        audio = nextAudioData.audio
+        audio = audioSource.playingSource
         audio.currentTime = nextAudioData.silence.starting_file / 1000
         currentAudioData.silence = nextAudioData.silence
         currentAudioData.filepath = nextAudioData.filepath
         maxSeekPercent.value = 0
+        audioSource.playPlayingSource(handlePlayErrors)
 
         clearNextAudioData()
         queue.moveForward()
@@ -365,15 +423,8 @@ export const usePlayer = defineStore('player', () => {
         maxSeekPercent.value = 0
 
         if (!queue.manual && queue.playing && audio.src !== '' && !audio.src.includes('sm.radio.jingles')) {
-            const oldAudio = audio
-            crossFade({
-                audio: oldAudio,
-                duration: settings.crossfade_duration,
-                start_volume: settings.volume,
-                then_destroy: true,
-            })
-            audio = new Audio()
-            audio.muted = settings.mute
+            audioSource.switchSources()
+            audio = audioSource.playingSource
         }
 
         const { currenttrack: track } = queue
@@ -381,6 +432,7 @@ export const usePlayer = defineStore('player', () => {
         const uri = getUrl(track.filepath, track.trackhash, settings.use_legacy_streaming_endpoint)
 
         audio.src = uri
+        audio.load() // on safari, audio won't play without load()
 
         clearNextAudioData()
         assignEventHandlers(audio)
@@ -418,4 +470,4 @@ export const usePlayer = defineStore('player', () => {
     }
 })
 
-export { audio, buffering, maxSeekPercent }
+export { audioSource, buffering, maxSeekPercent }

--- a/src/stores/queue.ts
+++ b/src/stores/queue.ts
@@ -7,7 +7,7 @@ import { Track } from '@/interfaces'
 import { isFavorite } from '@/requests/favorite'
 import useInterface from './interface'
 
-import { audio, getUrl, usePlayer } from '@/stores/player'
+import { audioSource, getUrl, usePlayer } from '@/stores/player'
 import useLyrics from './lyrics'
 import { NotifType, useToast } from './notification'
 import useTracklist from './queue/tracklist'
@@ -55,19 +55,19 @@ export default defineStore('Queue', {
             focusCurrentInSidebar()
         },
         playPause() {
-            if (audio.src === '') {
+            if (audioSource.playingSource.src === '') {
                 this.play(this.currentindex)
                 return
             }
 
-            if (audio.paused && !this.playing) {
-                audio.currentTime === 0 ? this.play(this.currentindex) : null
-                audio.play()
+            if (audioSource.playingSource.paused && !this.playing) {
+                audioSource.playingSource.currentTime === 0 ? this.play(this.currentindex) : null
+                audioSource.playPlayingSource()
                 this.playing = true
                 return
             }
 
-            audio.pause()
+            audioSource.pausePlayingSource()
             this.playing = false
         },
         autoPlayNext() {
@@ -88,8 +88,8 @@ export default defineStore('Queue', {
 
             const resetQueue = () => {
                 this.currentindex = 0
-                audio.src = getUrl(this.next.filepath, this.next.trackhash, settings.use_legacy_streaming_endpoint)
-                audio.pause()
+                audioSource.playingSource.src = getUrl(this.next.filepath, this.next.trackhash, settings.use_legacy_streaming_endpoint)
+                audioSource.pausePlayingSource()
                 this.playing = false
 
                 updateMediaNotif()
@@ -104,7 +104,7 @@ export default defineStore('Queue', {
         playPrev() {
             const lyrics = useLyrics()
 
-            if (audio.currentTime > 3) {
+            if (audioSource.playingSource.currentTime > 3) {
                 this.seek(0)
                 lyrics.setCurrentLine(-1)
                 return
@@ -120,7 +120,7 @@ export default defineStore('Queue', {
             const lyrics = useLyrics()
 
             try {
-                audio.currentTime = pos
+                audioSource.playingSource.currentTime = pos
                 this.duration.current = pos
             } catch (error) {
                 if (error instanceof TypeError) {

--- a/src/stores/tracker.ts
+++ b/src/stores/tracker.ts
@@ -2,7 +2,7 @@ import { ref } from "vue";
 import { defineStore } from "pinia";
 
 import useQueue from "./queue";
-import { audio } from "./player";
+import { audioSource } from "./player";
 import { FromOptions } from "@/enums";
 import useTracklist, { From } from "@/stores/queue/tracklist";
 
@@ -121,10 +121,10 @@ export default defineStore(
         trackhash.value = queue.currenttrackhash;
       }
 
-      audio.addEventListener(
+      audioSource.playingSource.addEventListener(
         "timeupdate",
         throttle(() => {
-          if (audio.paused) {
+          if (audioSource.playingSource.paused) {
             prev_date = 0;
           }
 

--- a/src/utils/audio/crossFade.ts
+++ b/src/utils/audio/crossFade.ts
@@ -67,8 +67,6 @@ export function crossFade({
     if (then_destroy) {
       audio.pause();
       audio.src = "";
-      // @ts-ignore
-      audio = null;
     }
   }
 }

--- a/src/views/ArtistView/Main.vue
+++ b/src/views/ArtistView/Main.vue
@@ -5,8 +5,11 @@
             :items="scrollerItems"
             :min-item-size="64"
             class="scroller"
-            style="height: 100%"
+            style="height: 100%;overflow-x: hidden;"
         >
+            <template #before>
+                <Header />
+            </template>
             <template #default="{ item, index, active }">
                 <DynamicScrollerItem
                     :item="item"
@@ -62,13 +65,6 @@ function fetchSimilarArtists() {
 function reFetchSimilarArtists() {
     store.resetSimilarArtists()
     return store.fetchSimilarArtists()
-}
-
-function getHeader() {
-    return <ScrollerItem>{
-        id: 'artist-header',
-        component: Header,
-    }
 }
 
 // const artist_albums_fetcher: ScrollerItem = {
@@ -167,7 +163,7 @@ const scrollerItems = computed(() => {
             source: 'artist',
         },
     }
-    let components = [getHeader()]
+    let components: ScrollerItem[] = []
 
     if (store.tracks.length > 0) {
         components.push(getTopTracksComponent())
@@ -255,6 +251,10 @@ onBeforeRouteLeave(() => store.resetAll())
     .statshead {
         padding: $medium;
         padding-top: 2rem;
+    }
+
+    .vue-recycle-scroller__item-view {
+        overflow: auto;
     }
 }
 </style>

--- a/src/views/NowPlaying/main.vue
+++ b/src/views/NowPlaying/main.vue
@@ -10,6 +10,9 @@
       class="scroller"
       style="height: 100%"
     >
+      <template #before>
+        <Header />
+      </template>
       <template #default="{ item, index, active }">
         <DynamicScrollerItem
           :item="item"
@@ -41,10 +44,6 @@ import Header from "@/components/NowPlaying/Header.vue";
 import SongItem from "@/components/shared/SongItem.vue";
 import updatePageTitle from "@/utils/updatePageTitle";
 
-const header: ScrollerItem = {
-  id: "header",
-  component: Header,
-};
 
 const queue = useQueueStore();
 const store = useTracklist();
@@ -54,7 +53,7 @@ function playFromQueue(index: number) {
 }
 
 const scrollerItems = computed(() => {
-  const items = [header];
+  const items: ScrollerItem[] = [];
 
   const trackComponents = store.tracklist.map((track, index) => {
     track.index = index; // used in context menu to remove from queue


### PR DESCRIPTION
# What this PR does
Fix various UI issues and make background playback on mobile possible.

## Fixes
- **`<body>` sizing error**: `vh`, `vw` works like `lvh`, `lvw` in Safari which makes part of `<body>` appears behind browser UI
- **scrolling bug cause by uneven elements size in `<DynamicScroller>`**: for touch screen, where scrolling up cause the page to jump back to item (index) `1`. fixed for **Artist** and **NowPlaying** view
- **dropdown arrow icon wrong sizing in safari**
- **playback won’t automatically continue/start when loading next song (pause then unpause fix it)**: this issue caused by Autoplay Policy. see [#229](https://github.com/swingmx/swingmusic/issues/229), [#212](https://github.com/swingmx/swingmusic/issues/212)
- **`.profiledrop` display behind `.smdropdown` element**
- **now playing on Tablet didn't show playback slide**

## Known Issues (that I can't/didn't fix)
- `mediaSession` in Safari will track the fading-out song and misunderstood that the playback has ended (and pause the `mediaSession`), manually set it as *"playing"* did nothing.
- when seeking to the last 30 seconds of the song, Safari would misunderstood that the playback has stopped.

# Testing
Tested on Android, IOS and Desktop devices I have, with the following browsers:
- Google Chrome (Android)
- Google Chrome (IOS)
- Safari (IOS)
- Arc Search (IOS)
- Arc (Windows)
- Microsoft Edge (Windows)