### PR TITLE
Add AutoShuffle toggle button

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -95,8 +95,9 @@ export interface DBSettings {
   removeRemasterInfo: boolean;
   mergeAlbums: boolean;
   showAlbumsAsSingles: boolean;
-  enablePeriodicScans: boolean
-  scanInterval: number
+  enablePeriodicScans: boolean;
+  scanInterval: number;
+  autoShuffle: boolean;
   plugins: Plugin[];
   version: string;
 }

--- a/src/helpers/usePlayFrom.ts
+++ b/src/helpers/usePlayFrom.ts
@@ -33,6 +33,7 @@ export async function utilPlayFromArtist(index: number = 0) {
     const tracks = await getArtistTracks(artist.info.artisthash)
 
     tracklist.setFromArtist(artist.info.artisthash, artist.info.name, tracks)
+    tracklist.shuffleListIfAutoShuffle()
     queue.play(index)
 }
 
@@ -48,6 +49,7 @@ export async function playFromAlbumCard(albumhash: string, albumname: string) {
     }
 
     tracklist.setFromAlbum(albumname, albumhash, tracks)
+    tracklist.shuffleListIfAutoShuffle()
     queue.play()
 }
 
@@ -62,6 +64,7 @@ export async function playFromArtistCard(artisthash: string, artistname: string)
     }
 
     tracklist.setFromArtist(artisthash, artistname, tracks)
+    tracklist.shuffleListIfAutoShuffle()
     queue.play()
 }
 
@@ -78,6 +81,7 @@ export async function playFromFolderCard(folderpath: string) {
     }
 
     tracklist.setFromFolder(folderpath, tracks)
+    tracklist.shuffleListIfAutoShuffle()
     queue.play()
 }
 
@@ -97,6 +101,9 @@ export async function playFromFavorites(track: Track | undefined) {
 
     if (track) {
         index = tracklist.tracklist.findIndex(t => t.trackhash === track?.trackhash)
+    }
+    else {
+        tracklist.shuffleListIfAutoShuffle()
     }
 
     console.log(tracklist.tracklist)
@@ -118,6 +125,7 @@ export async function playFromPlaylist(id: string, track?: Track) {
         const index = tracks.findIndex(t => t.trackhash === track.trackhash)
         queue.play(index)
     } else {
+        tracklist.shuffleListIfAutoShuffle()
         queue.play()
     }
 }
@@ -131,6 +139,7 @@ export const playFrom = async (source: playSources) => {
             const album = useAlbum()
 
             tracklist.setFromAlbum(album.info.title, album.info.albumhash, album.srcTracks)
+            tracklist.shuffleListIfAutoShuffle()
             queue.play()
             break
         }
@@ -144,6 +153,7 @@ export const playFrom = async (source: playSources) => {
                 await playlist.fetchAll(playlist.info.id, false, true)
             }
             tracklist.setFromPlaylist(playlist.info.name, playlist.info.id, playlist.tracks)
+            tracklist.shuffleListIfAutoShuffle()
             queue.play()
 
             break

--- a/src/settings/audio/groups.ts
+++ b/src/settings/audio/groups.ts
@@ -38,6 +38,14 @@ const crossfade: Setting = {
     show_if: () => settings().use_crossfade,
 }
 
+const auto_shuffle: Setting = {
+    title: 'Auto shuffle tracklist',
+    desc: 'Shuffle tracklist before start playing Playlist / Artist / Album',
+    type: SettingType.binary,
+    state: () => settings().auto_shuffle,
+    action: () => settings().toggleAutoShuffle(),
+}
+
 // const streaming_quality_options = [
 //     {
 //         title: 'Original',
@@ -79,4 +87,4 @@ const crossfade: Setting = {
 //     options: streaming_quality_options as any,
 // }
 
-export default [use_silence, use_crossfade, crossfade]
+export default [use_silence, use_crossfade, crossfade, auto_shuffle]

--- a/src/stores/queue/tracklist.ts
+++ b/src/stores/queue/tracklist.ts
@@ -146,6 +146,12 @@ export default defineStore('tracklist', {
         shuffleList() {
             this.tracklist = shuffle(this.tracklist)
         },
+        shuffleListIfAutoShuffle() {
+            const settings = useSettings()
+            if (settings.auto_shuffle) {
+                this.shuffleList()
+            }
+        },
         removeByIndex(index: number) {
             const {
                 currentindex,

--- a/src/stores/settings/index.ts
+++ b/src/stores/settings/index.ts
@@ -55,6 +55,7 @@ export default defineStore('settings', {
         use_crossfade: false,
         crossfade_duration: 2000, // milliseconds
         use_legacy_streaming_endpoint: false,
+        auto_shuffle: true,
 
         // layout
         layout: '',
@@ -203,6 +204,9 @@ export default defineStore('settings', {
 
         toggleUseLegacyStreamingEndpoint() {
             this.use_legacy_streaming_endpoint = !this.use_legacy_streaming_endpoint
+        },
+        toggleAutoShuffle() {
+            this.auto_shuffle = !this.auto_shuffle
         },
 
         // layout 👇


### PR DESCRIPTION
This PR add new toggle button to Audio / Playback settings tab

**PR purpose**

I always listen music in random order, so I have to do always two clicks: one for start playing and second for shuffle queue.

With this enabled feature tracklist will be autoshuffled when you click play button.

![image](https://github.com/user-attachments/assets/287d8783-50dc-4a61-bdbe-44a916fda120)
