### PR TITLE
feat: emit manifest.json for PWA support

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     svgLoader(),
     VitePWA({
       registerType: "autoUpdate",
+      manifestFilename: "manifest.json",
       devOptions: {
         enabled: true,
       },


### PR DESCRIPTION
## Why

The VitePWA plugin defaults to generating `manifest.webmanifest`.
Browsers and the Swing Music backend both look for `/manifest.json`, so
the default filename causes a 404 in production and prevents install
prompts from firing.

## What this PR does

1. **Sets `manifestFilename: "manifest.json"`** in `vite.config.ts` so
   VitePWA writes the manifest at `/manifest.json` (both in the dev
   server and in the production build output).

2. **Removes `public/site.webmanifest`** – this was an empty placeholder
   with incorrect icon paths. It is superseded by the manifest that
   VitePWA generates from the plugin configuration.

## Testing

```
yarn dev
curl -I http://localhost:5173/manifest.json
# → HTTP/1.1 200 OK
# → Content-Type: application/manifest+json
```

## Related

Companion PR in swingmx/swingmusic adds a `/manifest.json` route to
the Flask backend and a bundled fallback manifest for server-only
installs.